### PR TITLE
feat(makefile): remove deprecated version print

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 .DEFAULT_TARGET=help
-VERSION:=$(shell cat VERSION)
 
 ## help: Display list of commands
 .PHONY: help


### PR DESCRIPTION
Before commit 5ad5f7b30fa4a7e40adc7eb891a646277adf2fa the Makefile always displayed the version of yatas loaded from a `VERSION` file. However, since then, this file has been deleted.

This caused an error in the terminal at every command. For example:

```bash
$ make build
cat: VERSION: No such file or directory
go fmt ./...
go vet ./...
go build -o bin/yatas
```

This PR will remove the `cat: VERSION: No such file or directory` error message.