### PR TITLE
feat(global): remove all AWS references

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/padok-team/yatas
 go 1.19
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.16.16
 	github.com/fatih/color v1.13.0
 	github.com/google/go-github/v35 v35.3.0
 	github.com/hashicorp/go-hclog v1.4.0
@@ -14,7 +13,6 @@ require (
 )
 
 require (
-	github.com/aws/smithy-go v1.13.3 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-github.com/aws/aws-sdk-go-v2 v1.16.16 h1:M1fj4FE2lB4NzRb9Y0xdWsn2P0+2UHVxwKyOa4YJNjk=
-github.com/aws/aws-sdk-go-v2 v1.16.16/go.mod h1:SwiyXi/1zTUZ6KIAmLK5V5ll8SiURNUYOqTerZPaF9k=
-github.com/aws/smithy-go v1.13.3 h1:l7LYxGuzK6/K+NzJ2mC+VvLUbae0sL3bXU//04MkmnA=
-github.com/aws/smithy-go v1.13.3/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -16,7 +12,6 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v35 v35.3.0 h1:fU+WBzuukn0VssbayTT+Zo3/ESKX9JYWjbZTLOTEyho=
 github.com/google/go-github/v35 v35.3.0/go.mod h1:yWB7uCcVWaUbUP74Aq3whuMySRMatyRmq5U9FTNlbio=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -29,8 +24,6 @@ github.com/hashicorp/go-plugin v1.4.9/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHG
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
@@ -88,6 +81,5 @@ google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/plugins/commons/account.go
+++ b/plugins/commons/account.go
@@ -1,9 +1,0 @@
-package commons
-
-// AWS Account struct
-type AWS_Account struct {
-	Name    string `yaml:"name"`    // Name of the account in the reports
-	Profile string `yaml:"profile"` // Profile to use
-	SSO     bool   `yaml:"sso"`     // Use SSO
-	Region  string `yaml:"region"`  // Region to use
-}

--- a/plugins/commons/checkConfig.go
+++ b/plugins/commons/checkConfig.go
@@ -2,23 +2,19 @@ package commons
 
 import (
 	"sync"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 // CheckConfig is a struct that contains all the information needed to run a check.
 type CheckConfig struct {
 	Wg          *sync.WaitGroup // Wait group to wait for all the checks to be done
-	ConfigAWS   aws.Config      // AWS config
 	Queue       chan Check      // Queue to add the results to
 	ConfigYatas *Config         // Yatas config
 }
 
 // Init the check config struct. Particularly useful in the categories. It allows to pass the config to the checks and allows
 // them to be run in parallel by adding the results to the queue.
-func (c *CheckConfig) Init(s aws.Config, config *Config) {
+func (c *CheckConfig) Init(config *Config) {
 	c.Wg = &sync.WaitGroup{}
-	c.ConfigAWS = s
 	c.Queue = make(chan Check, 10)
 	c.ConfigYatas = config
 }

--- a/plugins/commons/config.go
+++ b/plugins/commons/config.go
@@ -9,7 +9,6 @@ import (
 
 type Config struct {
 	Plugins      []Plugin                 `yaml:"plugins"`
-	AWS          []AWS_Account            `yaml:"aws"`
 	Ignore       []Ignore                 `yaml:"ignore"`
 	PluginConfig []map[string]interface{} `yaml:"pluginsConfiguration"`
 	Tests        []Tests                  `yaml:"tests"`


### PR DESCRIPTION
## Changes

Remove all references to AWS, this may be a **breaking** change, as it require plugins depending on the last version of YATAS to update some function calls they make to the YATAS library.

## Plugins impacted

YATAS AWS will be impacted because it depends on the `AWS_Account` type that has been removed, but version 1.6.0 still functions with the new version of YATAS.