### PR TITLE
chore: migrate renovate config presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":automergePatch",
     ":semanticCommitTypeAll(chore)"
   ],
@@ -9,7 +9,7 @@
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "packageRules": [
     {
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "*"
       ],
       "matchUpdateTypes": [
@@ -19,7 +19,7 @@
       "groupSlug": "all-patch"
     },
     {
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "github.com/aws/aws-sdk-go-v2/service/*"
       ],
       "matchUpdateTypes": [


### PR DESCRIPTION
## Summary
- migrate Renovate from deprecated `config:base` to `config:recommended`
- rename deprecated `matchPackagePatterns` rules to `matchPackageNames`
- keep the existing patch grouping and AWS SDK minor grouping behavior

## Verification
- `python3 -m json.tool renovate.json`
- `git diff --check`

This addresses the `Config Migration Needed` item in the Dependency Dashboard without touching code or dependency versions.